### PR TITLE
Use maven-publish plugin

### DIFF
--- a/buildSrc/src/main/java/Values.kt
+++ b/buildSrc/src/main/java/Values.kt
@@ -1,4 +1,6 @@
 object ProjectConfig {
+  const val releaseVersion = "0.2.0-SNAPSHOT"
+
   const val compileSdkVersion = 30
   const val targetSdkVersion = 30
   const val minSdkVersion = 19

--- a/cast-framework-ktx/build.gradle
+++ b/cast-framework-ktx/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 }
 
 ext {
+  releaseVersion = ProjectConfig.releaseVersion
   releaseArtifactId = "cast-framework-ktx"
   libraryDescription = "KTX library for Cast SDK (play-services-cast-framework)"
 }

--- a/cast-framework-ktx/build.gradle
+++ b/cast-framework-ktx/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+plugins {
+  id("com.android.library")
+  id("kotlin-android")
+  id("maven-publish")
+}
 
 android {
   compileSdkVersion(ProjectConfig.compileSdkVersion)

--- a/cast-framework-ktx/build.gradle
+++ b/cast-framework-ktx/build.gradle
@@ -42,3 +42,10 @@ dependencies {
   testImplementation(Deps.truth)
   testImplementation(Deps.mockk)
 }
+
+ext {
+  releaseArtifactId = "cast-framework-ktx"
+  libraryDescription = "KTX library for Cast SDK (play-services-cast-framework)"
+}
+
+apply from: "../publish.gradle"

--- a/cast-ktx/build.gradle
+++ b/cast-ktx/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+plugins {
+  id("com.android.library")
+  id("kotlin-android")
+  id("maven-publish")
+}
 
 android {
   compileSdkVersion(ProjectConfig.compileSdkVersion)

--- a/cast-ktx/build.gradle
+++ b/cast-ktx/build.gradle
@@ -39,3 +39,10 @@ dependencies {
   testImplementation(Deps.robolectric)
   testImplementation(Deps.truth)
 }
+
+ext {
+  releaseArtifactId = "cast-ktx"
+  libraryDescription = "KTX library for Cast SDK (play-services-cast)"
+}
+
+apply from: "../publish.gradle"

--- a/cast-ktx/build.gradle
+++ b/cast-ktx/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 }
 
 ext {
+  releaseVersion = ProjectConfig.releaseVersion
   releaseArtifactId = "cast-ktx"
   libraryDescription = "KTX library for Cast SDK (play-services-cast)"
 }

--- a/cast-tv-ktx/build.gradle
+++ b/cast-tv-ktx/build.gradle
@@ -41,3 +41,10 @@ dependencies {
   testImplementation(Deps.truth)
   testImplementation(Deps.mockk)
 }
+
+ext {
+  releaseArtifactId = "cast-tv-ktx"
+  libraryDescription = "KTX library for Cast SDK (play-services-cast-tv)"
+}
+
+apply from: "../publish.gradle"

--- a/cast-tv-ktx/build.gradle
+++ b/cast-tv-ktx/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 }
 
 ext {
+  releaseVersion = ProjectConfig.releaseVersion
   releaseArtifactId = "cast-tv-ktx"
   libraryDescription = "KTX library for Cast SDK (play-services-cast-tv)"
 }

--- a/cast-tv-ktx/build.gradle
+++ b/cast-tv-ktx/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+plugins {
+  id("com.android.library")
+  id("kotlin-android")
+  id("maven-publish")
+}
 
 android {
   compileSdkVersion(ProjectConfig.compileSdkVersion)

--- a/publish.gradle
+++ b/publish.gradle
@@ -5,7 +5,7 @@ afterEvaluate {
         from components.release
         groupId = "com.github.nashcft.cast-sdk-ktx"
         artifactId = releaseArtifactId
-        version = "0.2.0-SNAPSHOT"
+        version = releaseVersion
         pom {
           name = releaseArtifactId
           description = libraryDescription

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,0 +1,34 @@
+afterEvaluate {
+  publishing {
+    publications {
+      release(MavenPublication) {
+        from components.release
+        groupId = "com.github.nashcft.cast-sdk-ktx"
+        artifactId = releaseArtifactId
+        version = "0.2.0-SNAPSHOT"
+        pom {
+          name = releaseArtifactId
+          description = libraryDescription
+          url = "https://github.com/nashcft/cast-sdk-ktx"
+          licenses {
+            license {
+              name = "The Apache License, Version 2.0"
+              url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          }
+          developers {
+            developer {
+              id = "nashcft"
+              name = "Nagahori Shota"
+            }
+          }
+          scm {
+            connection = "scm:git:git://github.com/nashcft/cast-sdk-ktx.git"
+            developerConnection = "scm:git:ssh://git@github.com/nashcft/cast-sdk-ktx.git"
+            url = "https://github.com/nashcft/cast-sdk-ktx"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Use [Maven Publish Plugin](https://docs.gradle.org/current/userguide/publishing_maven.html) for publication of the library artifacts.


## Context

JitPack uses [Android Maven Plugin](https://github.com/dcendents/android-maven-gradle-plugin) when project does not have configurations to publish artifacts to Maven repository, and the plugin causes following build error if the project uses Gradle 7.0.

```
> Configure project :
Gradle version Gradle 7.0

FAILURE: Build failed with an exception.

* Where:
Script '/script/maven-plugin.gradle' line: 2

* What went wrong:
A problem occurred evaluating script.
> Failed to apply plugin 'com.github.dcendents.android-maven'.
   > Could not create plugin of type 'AndroidMavenPlugin'.
      > Could not generate a decorated class for type AndroidMavenPlugin.
         > org/gradle/api/publication/maven/internal/MavenPomMetaInfoProvider
```

Android Maven Plugin has been abandoned and Android project now supports publication its artifacts to Maven repository with Maven Publish Plugin, so this project needs to use `maven-publish` plugin and add configurations for the publication to fix this problem.

## References

- https://developer.android.com/studio/build/maven-publish-plugin
- https://docs.gradle.org/current/userguide/publishing_maven.html
- https://jitpack.io/docs/ANDROID/